### PR TITLE
Update splunk-otel-java version to v2.4.0-alpha

### DIFF
--- a/apm/splunk-otel-java/metadata.yaml
+++ b/apm/splunk-otel-java/metadata.yaml
@@ -1,13 +1,13 @@
 component: Splunk Distribution of OpenTelemetry Java
-version: 2.3.0-alpha
+version: 2.4.0-alpha
 dependencies:
   - name: OpenTelemetry Java
     source_href: https://github.com/open-telemetry/opentelemetry-java
-    version: 1.37.0
+    version: 1.38.0
     stability: stable
   - name: OpenTelemetry Instrumentation for Java
     source_href: https://github.com/open-telemetry/opentelemetry-java-instrumentation
-    version: 2.3.0
+    version: 2.4.0
     stability: stable
   - name: OpenTelemetry Java Contrib Resource Providers
     source_href: https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/resource-providers
@@ -18,47 +18,54 @@ dependencies:
     version: 1.35.0-alpha
     stability: experimental
 settings:
-  - env: OTEL_SDK_DISABLED
+  - property: otel.sdk.disabled
+    env: OTEL_SDK_DISABLED
     description: If true, disable the OpenTelemetry SDK. Defaults to false.
     default: 'false'
     type: boolean
     category: general
-  - env: OTEL_TRACES_EXPORTER
+  - property: otel.traces.exporter
+    env: OTEL_TRACES_EXPORTER
     description: List of exporters to be used for tracing, separated by commas. Default
       is otlp. none means no autoconfigured exporter.
     default: otlp
     type: string
     category: exporter
-  - env: OTEL_METRICS_EXPORTER
+  - property: otel.metrics.exporter
+    env: OTEL_METRICS_EXPORTER
     description: List of exporters to be used for tracing, separated by commas. Default
       is otlp. none means no autoconfigured exporter.
     default: otlp
     type: string
     category: exporter
-  - env: OTEL_LOGS_EXPORTER
+  - property: otel.logs.exporter
+    env: OTEL_LOGS_EXPORTER
     description: List of exporters to be used for tracing, separated by commas. Default
       is otlp. none means no autoconfigured exporter.
     default: otlp
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_ENDPOINT
+  - property: otel.exporter.otlp.endpoint
+    env: OTEL_EXPORTER_OTLP_ENDPOINT
     description: The OTLP traces, metrics, and logs endpoint to connect to. Must be
       a URL with a scheme of either http or https based on the use of TLS. If protocol
       is http/protobuf the version and signal will be appended to the path (e.g. v1/traces,
       v1/metrics, or v1/logs). Default is http://localhost:4317 when protocol is grpc,
       and http://localhost:4318/v1/{signal} when protocol is http/protobuf.
-    default: http://localhost:4317
+    default: http://localhost:4318
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+  - property: otel.exporter.otlp.traces.endpoint
+    env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
     description: The OTLP traces endpoint to connect to. Must be a URL with a scheme
       of either http or https based on the use of TLS. Default is http://localhost:4317
       when protocol is grpc, and http://localhost:4318/v1/traces when protocol is
       http/protobuf.
-    default: http://localhost:4317
+    default: http://localhost:4318/v1/traces
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
+  - property: otel.exporter.otlp.metrics.endpoint
+    env: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
     description: The OTLP metrics endpoint to connect to. Must be a URL with a scheme
       of either http or https based on the use of TLS. Default is http://localhost:4317
       when protocol is grpc, and http://localhost:4318/v1/metrics when protocol is
@@ -66,14 +73,16 @@ settings:
     default: http://localhost:4318/v1/metrics
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
+  - property: otel.exporter.otlp.logs.endpoint
+    env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
     description: The OTLP logs endpoint to connect to. Must be a URL with a scheme
       of either http or https based on the use of TLS. Default is http://localhost:4317
       when protocol is grpc, and http://localhost:4318/v1/logs when protocol is http/protobuf.
-    default: http://localhost:4317
+    default: http://localhost:4318/v1/logs
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_CERTIFICATE
+  - property: otel.exporter.otlp.certificate
+    env: OTEL_EXPORTER_OTLP_CERTIFICATE
     description: The path to the file containing trusted certificates to use when
       verifying an OTLP trace, metric, or log server's TLS credentials. The file should
       contain one or more X.509 certificates in PEM format. By default the host platform's
@@ -81,7 +90,8 @@ settings:
     default: ''
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE
+  - property: otel.exporter.otlp.traces.certificate
+    env: OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE
     description: The path to the file containing trusted certificates to use when
       verifying an OTLP trace server's TLS credentials. The file should contain one
       or more X.509 certificates in PEM format. By default the host platform's trusted
@@ -89,7 +99,8 @@ settings:
     default: ''
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE
+  - property: otel.exporter.otlp.metrics.certificate
+    env: OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE
     description: The path to the file containing trusted certificates to use when
       verifying an OTLP metric server's TLS credentials. The file should contain one
       or more X.509 certificates in PEM format. By default the host platform's trusted
@@ -97,7 +108,8 @@ settings:
     default: ''
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE
+  - property: otel.exporter.otlp.logs.certificate
+    env: OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE
     description: The path to the file containing trusted certificates to use when
       verifying an OTLP log server's TLS credentials. The file should contain one
       or more X.509 certificates in PEM format. By default the host platform's trusted
@@ -105,35 +117,40 @@ settings:
     default: ''
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_CLIENT_KEY
+  - property: otel.exporter.otlp.client.key
+    env: OTEL_EXPORTER_OTLP_CLIENT_KEY
     description: The path to the file containing private client key to use when verifying
       an OTLP trace, metric, or log client's TLS credentials. The file should contain
       one private key PKCS8 PEM format. By default no client key is used.
     default: ''
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_TRACES_CLIENT_KEY
+  - property: otel.exporter.otlp.traces.client.key
+    env: OTEL_EXPORTER_OTLP_TRACES_CLIENT_KEY
     description: The path to the file containing private client key to use when verifying
       an OTLP trace client's TLS credentials. The file should contain one private
       key PKCS8 PEM format. By default no client key file is used.
     default: ''
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY
+  - property: otel.exporter.otlp.metrics.client.key
+    env: OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY
     description: The path to the file containing private client key to use when verifying
       an OTLP metric client's TLS credentials. The file should contain one private
       key PKCS8 PEM format. By default no client key file is used.
     default: ''
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY
+  - property: otel.exporter.otlp.logs.client.key
+    env: OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY
     description: The path to the file containing private client key to use when verifying
       an OTLP log client's TLS credentials. The file should contain one private key
       PKCS8 PEM format. By default no client key file is used.
     default: ''
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE
+  - property: otel.exporter.otlp.client.certificate
+    env: OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE
     description: The path to the file containing trusted certificates to use when
       verifying an OTLP trace, metric, or log client's TLS credentials. The file should
       contain one or more X.509 certificates in PEM format. By default no chain file
@@ -141,124 +158,144 @@ settings:
     default: ''
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE
+  - property: otel.exporter.otlp.traces.client.certificate
+    env: OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE
     description: The path to the file containing trusted certificates to use when
       verifying an OTLP trace server's TLS credentials. The file should contain one
       or more X.509 certificates in PEM format. By default no chain file is used.
     default: ''
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE
+  - property: otel.exporter.otlp.metrics.client.certificate
+    env: OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE
     description: The path to the file containing trusted certificates to use when
       verifying an OTLP metric server's TLS credentials. The file should contain one
       or more X.509 certificates in PEM format. By default no chain file is used.
     default: ''
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_LOGS_CLIENT_CERTIFICATE
+  - property: otel.exporter.otlp.logs.client.certificate
+    env: OTEL_EXPORTER_OTLP_LOGS_CLIENT_CERTIFICATE
     description: The path to the file containing trusted certificates to use when
       verifying an OTLP log server's TLS credentials. The file should contain one
       or more X.509 certificates in PEM format. By default no chain file is used.
     default: ''
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_HEADERS
+  - property: otel.exporter.otlp.headers
+    env: OTEL_EXPORTER_OTLP_HEADERS
     description: Key-value pairs separated by commas to pass as request headers on
       OTLP trace, metric, and log requests.
     default: ''
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_TRACES_HEADERS
+  - property: otel.exporter.otlp.traces.headers
+    env: OTEL_EXPORTER_OTLP_TRACES_HEADERS
     description: Key-value pairs separated by commas to pass as request headers on
       OTLP trace requests.
     default: ''
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_METRICS_HEADERS
+  - property: otel.exporter.otlp.metrics.headers
+    env: OTEL_EXPORTER_OTLP_METRICS_HEADERS
     description: Key-value pairs separated by commas to pass as request headers on
       OTLP metrics requests.
     default: ''
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_LOGS_HEADERS
+  - property: otel.exporter.otlp.logs.headers
+    env: OTEL_EXPORTER_OTLP_LOGS_HEADERS
     description: Key-value pairs separated by commas to pass as request headers on
       OTLP logs requests.
     default: ''
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_COMPRESSION
+  - property: otel.exporter.otlp.compression
+    env: OTEL_EXPORTER_OTLP_COMPRESSION
     description: The compression type to use on OTLP trace, metric, and log requests.
       Options include gzip. By default no compression will be used.
     default: ''
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_TRACES_COMPRESSION
+  - property: otel.exporter.otlp.traces.compression
+    env: OTEL_EXPORTER_OTLP_TRACES_COMPRESSION
     description: The compression type to use on OTLP trace requests. Options include
       gzip. By default no compression will be used.
     default: ''
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_METRICS_COMPRESSION
+  - property: otel.exporter.otlp.metrics.compression
+    env: OTEL_EXPORTER_OTLP_METRICS_COMPRESSION
     description: The compression type to use on OTLP metric requests. Options include
       gzip. By default no compression will be used.
     default: ''
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_LOGS_COMPRESSION
+  - property: otel.exporter.otlp.logs.compression
+    env: OTEL_EXPORTER_OTLP_LOGS_COMPRESSION
     description: The compression type to use on OTLP log requests. Options include
       gzip. By default no compression will be used.
     default: ''
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_TIMEOUT
+  - property: otel.exporter.otlp.timeout
+    env: OTEL_EXPORTER_OTLP_TIMEOUT
     description: The maximum waiting time, in milliseconds, allowed to send each OTLP
       trace, metric, and log batch. Default is 10000.
     default: '10000'
     type: int
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_TRACES_TIMEOUT
+  - property: otel.exporter.otlp.traces.timeout
+    env: OTEL_EXPORTER_OTLP_TRACES_TIMEOUT
     description: The maximum waiting time, in milliseconds, allowed to send each OTLP
       trace batch. Default is 10000.
     default: '10000'
     type: int
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_METRICS_TIMEOUT
+  - property: otel.exporter.otlp.metrics.timeout
+    env: OTEL_EXPORTER_OTLP_METRICS_TIMEOUT
     description: The maximum waiting time, in milliseconds, allowed to send each OTLP
       metric batch. Default is 10000.
     default: '10000'
     type: int
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_LOGS_TIMEOUT
+  - property: otel.exporter.otlp.logs.timeout
+    env: OTEL_EXPORTER_OTLP_LOGS_TIMEOUT
     description: The maximum waiting time, in milliseconds, allowed to send each OTLP
       log batch. Default is 10000.
     default: '10000'
     type: int
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_PROTOCOL
+  - property: otel.exporter.otlp.protocol
+    env: OTEL_EXPORTER_OTLP_PROTOCOL
     description: The transport protocol to use on OTLP trace, metric, and log requests.
       Options include grpc and http/protobuf.
     default: http/protobuf
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+  - property: otel.exporter.otlp.traces.protocol
+    env: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
     description: The transport protocol to use on OTLP trace requests. Options include
       grpc and http/protobuf.
     default: http/protobuf
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_METRICS_PROTOCOL
+  - property: otel.exporter.otlp.metrics.protocol
+    env: OTEL_EXPORTER_OTLP_METRICS_PROTOCOL
     description: The transport protocol to use on OTLP metric requests. Options include
       grpc and http/protobuf.
     default: http/protobuf
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_LOGS_PROTOCOL
+  - property: otel.exporter.otlp.logs.protocol
+    env: OTEL_EXPORTER_OTLP_LOGS_PROTOCOL
     description: The transport protocol to use on OTLP log requests. Options include
       grpc and http/protobuf.
     default: http/protobuf
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+  - property: otel.exporter.otlp.metrics.temporality.preference
+    env: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
     description: The preferred output aggregation temporality. Options include DELTA,
       LOWMEMORY, and CUMULATIVE. If CUMULATIVE, all instruments will have cumulative
       temporality. If DELTA, counter (sync and async) and histograms will be delta,
@@ -268,188 +305,227 @@ settings:
     default: CUMULATIVE
     type: string
     category: exporter
-  - env: OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION
+  - property: otel.exporter.otlp.metrics.default.histogram.aggregation
+    env: OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION
     description: The preferred default histogram aggregation. Options include BASE2_EXPONENTIAL_BUCKET_HISTOGRAM
       and EXPLICIT_BUCKET_HISTOGRAM. Default is EXPLICIT_BUCKET_HISTOGRAM.
     default: EXPLICIT_BUCKET_HISTOGRAM
     type: string
     category: exporter
-  - env: OTEL_EXPERIMENTAL_EXPORTER_OTLP_RETRY_ENABLED
+  - property: otel.experimental.exporter.otlp.retry.enabled
+    env: OTEL_EXPERIMENTAL_EXPORTER_OTLP_RETRY_ENABLED
     description: If true, enable experimental retry support. Default is false.
     default: 'false'
     type: boolean
     category: exporter
-  - env: OTEL_RESOURCE_ATTRIBUTES
+  - property: otel.resource.attributes
+    env: OTEL_RESOURCE_ATTRIBUTES
     description: 'Specify resource attributes in the following format: key1=val1,key2=val2,key3=val3'
     default: ''
     type: string
     category: instrumentation
-  - env: OTEL_SERVICE_NAME
+  - property: otel.service.name
+    env: OTEL_SERVICE_NAME
     description: Specify logical service name. Takes precedence over service.name
       defined with otel.resource.attributes
     default: ''
     type: string
     category: instrumentation
-  - env: OTEL_EXPERIMENTAL_RESOURCE_DISABLED_KEYS
+  - property: otel.experimental.resource.disabled-keys
+    env: OTEL_EXPERIMENTAL_RESOURCE_DISABLED_KEYS
     description: Specify resource attribute keys that are filtered.
     default: ''
     type: string
     category: instrumentation
-  - env: OTEL_JAVA_ENABLED_RESOURCE_PROVIDERS
+  - property: otel.java.enabled.resource.providers
+    env: OTEL_JAVA_ENABLED_RESOURCE_PROVIDERS
     description: Enables one or more ResourceProvider types. If unset, all resource
       providers are enabled.
     default: ''
     type: string
     category: resource provider
-  - env: OTEL_JAVA_DISABLED_RESOURCE_PROVIDERS
+  - property: otel.java.disabled.resource.providers
+    env: OTEL_JAVA_DISABLED_RESOURCE_PROVIDERS
     description: Disables one or more ResourceProvider types.
     default: ''
     type: string
     category: resource provider
-  - env: OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT
+  - property: otel.attribute.value.length.limit
+    env: OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT
     description: The maximum length of attribute values. Applies to spans and logs.
       By default there is no limit.
     default: ''
     type: int
     category: instrumentation
-  - env: OTEL_ATTRIBUTE_COUNT_LIMIT
+  - property: otel.attribute.count.limit
+    env: OTEL_ATTRIBUTE_COUNT_LIMIT
     description: The maximum number of attributes. Applies to spans, span events,
       span links, and logs. Default is 128.
     default: '128'
     type: int
     category: instrumentation
-  - env: OTEL_PROPAGATORS
+  - property: otel.propagators
+    env: OTEL_PROPAGATORS
     description: The propagators to be used. Use a comma-separated list for multiple
       propagators. Default is tracecontext,baggage (W3C).
     default: tracecontext,baggage
     type: string
     category: general
-  - env: OTEL_EXPORTER_ZIPKIN_ENDPOINT
+  - property: otel.exporter.zipkin.endpoint
+    env: OTEL_EXPORTER_ZIPKIN_ENDPOINT
     description: The Zipkin endpoint to connect to. Default is http://localhost:9411/api/v2/spans.
       Currently only HTTP is supported.
     default: http://localhost:9411/api/v2/spans
     type: string
     category: exporter
-  - env: OTEL_BSP_SCHEDULE_DELAY
+  - property: otel.bsp.schedule.delay
+    env: OTEL_BSP_SCHEDULE_DELAY
     description: The interval, in milliseconds, between two consecutive exports. Default
       is 5000.
     default: '5000'
     type: int
     category: general
-  - env: OTEL_BSP_MAX_QUEUE_SIZE
+  - property: otel.bsp.max.queue.size
+    env: OTEL_BSP_MAX_QUEUE_SIZE
     description: The maximum queue size. Default is 2048.
     default: '2048'
     type: int
     category: general
-  - env: OTEL_BSP_MAX_EXPORT_BATCH_SIZE
+  - property: otel.bsp.max.export.batch.size
+    env: OTEL_BSP_MAX_EXPORT_BATCH_SIZE
     description: The maximum batch size. Default is 512.
     default: '512'
     type: int
     category: general
-  - env: OTEL_BSP_EXPORT_TIMEOUT
+  - property: otel.bsp.export.timeout
+    env: OTEL_BSP_EXPORT_TIMEOUT
     description: The maximum allowed time, in milliseconds, to export data. Default
       is 30000.
     default: '30000'
     type: int
     category: general
-  - env: OTEL_TRACES_SAMPLER
+  - property: otel.traces.sampler
+    env: OTEL_TRACES_SAMPLER
     description: The sampler to use for tracing. Defaults to parentbased_always_on
     default: always_on
     type: string
     category: general
-  - env: OTEL_TRACES_SAMPLER_ARG
+  - property: otel.traces.sampler.arg
+    env: OTEL_TRACES_SAMPLER_ARG
     description: An argument to the configured tracer if supported, for example a
       ratio.
     default: ''
     type: string
     category: general
-  - env: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
+  - property: otel.span.attribute.value.length.limit
+    env: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
     description: The maximum length of span attribute values. Takes precedence over
       otel.attribute.value.length.limit. By default there is no limit.
     default: ''
     type: int
     category: instrumentation
-  - env: OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
+  - property: otel.span.attribute.count.limit
+    env: OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
     description: The maximum number of attributes per span. Takes precedence over
       otel.attribute.count.limit. Default is 128.
     default: '128'
     type: int
     category: instrumentation
-  - env: OTEL_SPAN_EVENT_COUNT_LIMIT
+  - property: otel.span.event.count.limit
+    env: OTEL_SPAN_EVENT_COUNT_LIMIT
     description: The maximum number of events per span. Default is 128.
     default: '128'
     type: int
     category: instrumentation
-  - env: OTEL_SPAN_LINK_COUNT_LIMIT
+  - property: otel.span.link.count.limit
+    env: OTEL_SPAN_LINK_COUNT_LIMIT
     description: TThe maximum number of links per span. Default is 128.
     default: '128'
     type: int
     category: instrumentation
-  - env: OTEL_METRICS_EXEMPLAR_FILTER
+  - property: otel.metrics.exemplar.filter
+    env: OTEL_METRICS_EXEMPLAR_FILTER
     description: The filter for exemplar sampling. Can be ALWAYS_OFF, ALWAYS_ON or
       TRACE_BASED. Default is TRACE_BASED.
     default: TRACE_BASED
     type: string
     category: general
-  - env: OTEL_METRIC_EXPORT_INTERVAL
+  - property: otel.metric.export.interval
+    env: OTEL_METRIC_EXPORT_INTERVAL
     description: The interval, in milliseconds, between the start of two export attempts.
       Default is 60000.
     default: '60000'
     type: int
     category: exporter
-  - env: OTEL_EXPORTER_PROMETHEUS_PORT
+  - property: otel.exporter.prometheus.port
+    env: OTEL_EXPORTER_PROMETHEUS_PORT
     description: The local port used to bind the prometheus metric server. Default
       is 9464.
     default: '9464'
     type: int
     category: exporter
-  - env: OTEL_EXPORTER_PROMETHEUS_HOST
+  - property: otel.exporter.prometheus.host
+    env: OTEL_EXPORTER_PROMETHEUS_HOST
     description: The local address used to bind the prometheus metric server. Default
       is 0.0.0.0.
     default: 0.0.0.0
     type: int
     category: exporter
-  - env: OTEL_EXPERIMENTAL_METRICS_CARDINALITY_LIMIT
+  - property: otel.experimental.metrics.cardinality.limit
+    env: OTEL_EXPERIMENTAL_METRICS_CARDINALITY_LIMIT
     description: If set, configure experimental cardinality limit. The value dictates
       the maximum number of distinct points per metric. Default is 2000.
     default: '2000'
     type: int
     category: instrumentation
-  - env: OTEL_BLRP_SCHEDULE_DELAY
+  - property: otel.blrp.schedule.delay
+    env: OTEL_BLRP_SCHEDULE_DELAY
     description: The interval, in milliseconds, between two consecutive exports. Default
       is 1000.
     default: '1000'
     type: int
     category: general
-  - env: OTEL_BLRP_MAX_QUEUE_SIZE
+  - property: otel.blrp.max.queue.size
+    env: OTEL_BLRP_MAX_QUEUE_SIZE
     description: The maximum queue size. Default is 2048.
     default: '2048'
     type: int
     category: general
-  - env: OTEL_BLRP_MAX_EXPORT_BATCH_SIZE
+  - property: otel.blrp.max.export.batch.size
+    env: OTEL_BLRP_MAX_EXPORT_BATCH_SIZE
     description: The maximum batch size. Default is 512.
     default: '512'
     type: int
     category: general
-  - env: OTEL_BLRP_EXPORT_TIMEOUT
+  - property: otel.blrp.export.timeout
+    env: OTEL_BLRP_EXPORT_TIMEOUT
     description: The maximum allowed time, in milliseconds, to export data. Default
       is 30000.
     default: '30000'
     type: int
     category: general
-  - env: OTEL_JAVAAGENT_CONFIGURATION_FILE
+  - property: otel.config.file
+    env: OTEL_CONFIG_FILE
+    description: The path to the SDK configuration file. Defaults to unset.
+    default: ''
+    type: string
+    category: general
+  - property: otel.javaagent.configuration-file
+    env: OTEL_JAVAAGENT_CONFIGURATION_FILE
     description: Path to valid Java properties file which contains the agent configuration.
     default: ''
     type: string
     category: general
-  - env: OTEL_JAVAAGENT_EXTENSIONS
+  - property: otel.javaagent.extensions
+    env: OTEL_JAVAAGENT_EXTENSIONS
     description: Path to an extension jar file or folder, containing jar files. If
       pointing to a folder, every jar file in that folder will be treated as separate,
       independent extension.
     default: ''
     type: string
     category: general
-  - env: OTEL_JAVAAGENT_LOGGING
+  - property: otel.javaagent.logging
+    env: OTEL_JAVAAGENT_LOGGING
     description: |-
       The Java agent logging mode. The following 3 modes are supported:
       simple: The agent will print out its logs using the standard error stream. Only INFO or higher logs will be printed. This is the default Java agent logging mode.
@@ -458,7 +534,8 @@ settings:
     default: simple
     type: string
     category: general
-  - env: OTEL_INSTRUMENTATION_COMMON_PEER_SERVICE_MAPPING
+  - property: otel.instrumentation.common.peer-service-mapping
+    env: OTEL_INSTRUMENTATION_COMMON_PEER_SERVICE_MAPPING
     description: Used to specify a mapping from host names or IP addresses to peer
       services, as a comma-separated list of &lt;host_or_ip&gt;=&lt;user_assigned_name&gt;
       pairs. The peer service is added as an attribute to a span whose host or IP
@@ -466,99 +543,117 @@ settings:
     default: ''
     type: string
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_COMMON_DB_STATEMENT_SANITIZER_ENABLED
+  - property: otel.instrumentation.common.db-statement-sanitizer.enabled
+    env: OTEL_INSTRUMENTATION_COMMON_DB_STATEMENT_SANITIZER_ENABLED
     description: Enables the DB statement sanitization.
     default: 'true'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_REQUEST_HEADERS
+  - property: otel.instrumentation.http.client.capture-request-headers
+    env: OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_REQUEST_HEADERS
     description: A comma-separated list of HTTP header names. HTTP client instrumentations
       will capture HTTP request header values for all configured header names.
     default: ''
     type: string
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_RESPONSE_HEADERS
+  - property: otel.instrumentation.http.client.capture-response-headers
+    env: OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_RESPONSE_HEADERS
     description: A comma-separated list of HTTP header names. HTTP client instrumentations
       will capture HTTP response header values for all configured header names.
     default: ''
     type: string
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_HTTP_SERVER_CAPTURE_REQUEST_HEADERS
+  - property: otel.instrumentation.http.server.capture-request-headers
+    env: OTEL_INSTRUMENTATION_HTTP_SERVER_CAPTURE_REQUEST_HEADERS
     description: A comma-separated list of HTTP header names. HTTP server instrumentations
       will capture HTTP request header values for all configured header names.
     default: ''
     type: string
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_HTTP_SERVER_CAPTURE_RESPONSE_HEADERS
+  - property: otel.instrumentation.http.server.capture-response-headers
+    env: OTEL_INSTRUMENTATION_HTTP_SERVER_CAPTURE_RESPONSE_HEADERS
     description: A comma-separated list of HTTP header names. HTTP server instrumentations
       will capture HTTP response header values for all configured header names.
     default: ''
     type: string
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_SERVLET_EXPERIMENTAL_CAPTURE_REQUEST_PARAMETERS
+  - property: otel.instrumentation.servlet.experimental.capture-request-parameters
+    env: OTEL_INSTRUMENTATION_SERVLET_EXPERIMENTAL_CAPTURE_REQUEST_PARAMETERS
     description: A comma-separated list of request parameter names.
     default: ''
     type: string
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_MESSAGING_EXPERIMENTAL_RECEIVE_TELEMETRY_ENABLED
+  - property: otel.instrumentation.messaging.experimental.receive-telemetry.enabled
+    env: OTEL_INSTRUMENTATION_MESSAGING_EXPERIMENTAL_RECEIVE_TELEMETRY_ENABLED
     description: Enables the consumer message receive telemetry. Note that this will
       cause the consumer side to start a new trace, with only a span link connecting
       it to the producer trace.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_COMMON_ENDUSER_ENABLED
+  - property: otel.instrumentation.common.enduser.enabled
+    env: OTEL_INSTRUMENTATION_COMMON_ENDUSER_ENABLED
     description: Common flag for enabling/disabling enduser attributes.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_COMMON_ENDUSER_ID_ENABLED
+  - property: otel.instrumentation.common.enduser.id.enabled
+    env: OTEL_INSTRUMENTATION_COMMON_ENDUSER_ID_ENABLED
     description: Determines whether to capture `enduser.id` semantic attribute.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_COMMON_ENDUSER_ROLE_ENABLED
+  - property: otel.instrumentation.common.enduser.role.enabled
+    env: OTEL_INSTRUMENTATION_COMMON_ENDUSER_ROLE_ENABLED
     description: Determines whether to capture `enduser.role` semantic attribute.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_COMMON_ENDUSER_SCOPE_ENABLED
+  - property: otel.instrumentation.common.enduser.scope.enabled
+    env: OTEL_INSTRUMENTATION_COMMON_ENDUSER_SCOPE_ENABLED
     description: Determines whether to capture `enduser.scope` semantic attribute.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_HTTP_CLIENT_EMIT_EXPERIMENTAL_TELEMETRY
+  - property: otel.instrumentation.http.client.emit-experimental-telemetry
+    env: OTEL_INSTRUMENTATION_HTTP_CLIENT_EMIT_EXPERIMENTAL_TELEMETRY
     description: Enables experimental http client telemetry.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_HTTP_SERVER_EMIT_EXPERIMENTAL_TELEMETRY
+  - property: otel.instrumentation.http.server.emit-experimental-telemetry
+    env: OTEL_INSTRUMENTATION_HTTP_SERVER_EMIT_EXPERIMENTAL_TELEMETRY
     description: Enables experimental http server telemetry.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_COMMON_DEFAULT_ENABLED
+  - property: otel.instrumentation.common.default-enabled
+    env: OTEL_INSTRUMENTATION_COMMON_DEFAULT_ENABLED
     description: Disable all instrumentations in the agent.
     default: 'true'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_{NAME}_ENABLED
-    description: Suppresses agent instrumentation of specific library where `{NAME}`
+  - property: otel.instrumentation.{name}.enabled
+    env: OTEL_INSTRUMENTATION_{NAME}_ENABLED
+    description: Suppresses agent instrumentation of specific library where `{name}`
       is the corresponding instrumentation name.
     default: ''
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_COMMON_EXPERIMENTAL_CONTROLLER_TELEMETRY_ENABLED
+  - property: otel.instrumentation.common.experimental.controller-telemetry.enabled
+    env: OTEL_INSTRUMENTATION_COMMON_EXPERIMENTAL_CONTROLLER_TELEMETRY_ENABLED
     description: Enables the controller telemetry.
-    default: 'true'
+    default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_COMMON_EXPERIMENTAL_VIEW_TELEMETRY_ENABLED
+  - property: otel.instrumentation.common.experimental.view-telemetry.enabled
+    env: OTEL_INSTRUMENTATION_COMMON_EXPERIMENTAL_VIEW_TELEMETRY_ENABLED
     description: Enables the view telemetry.
-    default: 'true'
+    default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_EXPERIMENTAL_SPAN_SUPPRESSION_STRATEGY
+  - property: otel.instrumentation.experimental.span-suppression-strategy
+    env: OTEL_INSTRUMENTATION_EXPERIMENTAL_SPAN_SUPPRESSION_STRATEGY
     description: |
       The Java agent span suppression strategy. The following 3 strategies are supported:
       semconv: The agent will suppress duplicate semantic conventions. This is the default behavior of the Java agent.
@@ -567,479 +662,593 @@ settings:
     default: semconv
     type: string
     category: instrumentation
-  - env: OTEL_JAVAAGENT_EXCLUDE_CLASSES
+  - property: otel.javaagent.exclude-classes
+    env: OTEL_JAVAAGENT_EXCLUDE_CLASSES
     description: Suppresses all instrumentation for specific classes, format is "my.package.MyClass,my.package2.*".
     default: ''
     type: string
     category: general
-  - env: OTEL_JAVAAGENT_EXCLUDE_CLASS_LOADERS
+  - property: otel.javaagent.exclude-class-loaders
+    env: OTEL_JAVAAGENT_EXCLUDE_CLASS_LOADERS
     description: Ignore the specified class loaders, format is "my.package.MyClass,my.package2.".
     default: ''
     type: string
     category: general
-  - env: OTEL_JAVAAGENT_EXPERIMENTAL_SECURITY_MANAGER_SUPPORT_ENABLED
+  - property: otel.javaagent.experimental.security-manager-support.enabled
+    env: OTEL_JAVAAGENT_EXPERIMENTAL_SECURITY_MANAGER_SUPPORT_ENABLED
     description: 'Grant all privileges to agent code. Disclaimer: agent can provide
       application means for escaping security manager sandbox. Do not usethis option
       if your application relies on security manager to run untrusted code.'
     default: 'false'
     type: boolean
     category: general
-  - env: OTEL_RESOURCE_PROVIDERS_AWS_ENABLED
+  - property: otel.resource.providers.aws.enabled
+    env: OTEL_RESOURCE_PROVIDERS_AWS_ENABLED
     description: Enables the AWS Resource Provider.
     default: 'false'
     type: boolean
     category: resource provider
-  - env: OTEL_RESOURCE_PROVIDERS_GCP_ENABLED
+  - property: otel.resource.providers.gcp.enabled
+    env: OTEL_RESOURCE_PROVIDERS_GCP_ENABLED
     description: Enables the GCP Resource Provider.
     default: 'false'
     type: boolean
     category: resource provider
-  - env: SPLUNK_ACCESS_TOKEN
+  - property: splunk.access.token
+    env: SPLUNK_ACCESS_TOKEN
     description: (Optional) Auth token allowing exporters to communicate directly
       with the Splunk cloud, passed as X-SF-TOKEN header.
     default: ''
     type: string
     category: general
-  - env: SPLUNK_REALM
+  - property: splunk.realm
+    env: SPLUNK_REALM
     description: The Splunk Observability Cloud realm where the telemetry should be
       sent to. For example, us0 or us1. Defaults to none, which means that data goes
       to a Splunk OpenTelemetry Collector deployed on localhost.
     default: none
     type: string
     category: general
-  - env: SPLUNK_METRICS_ENABLED
-    description: Enables exporting splunk metrics.
-    default: 'false'
-    type: boolean
-    category: general
-  - env: SPLUNK_METRICS_FORCE_FULL_COMMANDLINE
+  - property: splunk.metrics.force_full_commandline
+    env: SPLUNK_METRICS_FORCE_FULL_COMMANDLINE
     description: Adds the full command line as a resource attribute for all metrics.
       If false, commands longer than 255 characters are truncated.
     default: 'false'
     type: boolean
     category: general
-  - env: SPLUNK_TRACE_RESPONSE_HEADER_ENABLED
+  - property: splunk.trace-response-header.enabled
+    env: SPLUNK_TRACE_RESPONSE_HEADER_ENABLED
     description: Enables adding server trace information to HTTP response headers.
       See this document for more information.
     default: 'true'
     type: boolean
     category: general
-  - env: OTEL_INSTRUMENTATION_METHODS_INCLUDE
+  - property: otel.instrumentation.methods.include
+    env: OTEL_INSTRUMENTATION_METHODS_INCLUDE
     description: Same as adding @WithSpan annotation functionality for the target
       method string, e.g. my.package.MyClass1[method1,method2];my.package.MyClass2[method3]
     default: ''
     type: string
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_OPENTELEMETRY_ANNOTATIONS_EXCLUDE_METHODS
+  - property: otel.instrumentation.opentelemetry-annotations.exclude-methods
+    env: OTEL_INSTRUMENTATION_OPENTELEMETRY_ANNOTATIONS_EXCLUDE_METHODS
     description: Suppress @WithSpan instrumentation for specific methods, e.g. my.package.MyClass1[method1,method2];my.package.MyClass2[method3]
     default: ''
     type: string
     category: instrumentation
-  - env: SPLUNK_PROFILER_ENABLED
+  - property: splunk.profiler.enabled
+    env: SPLUNK_PROFILER_ENABLED
     description: Enables cpu profiler.
     default: 'false'
     type: boolean
     category: profiler
-  - env: SPLUNK_PROFILER_DIRECTORY
+  - property: splunk.profiler.directory
+    env: SPLUNK_PROFILER_DIRECTORY
     description: Location of JFR files, defaults to System.getProperty("java.io.tmpdir").
     default: value of System.getProperty("java.io.tmpdir")
     type: string
     category: profiler
-  - env: SPLUNK_PROFILER_RECORDING_DURATION
+  - property: splunk.profiler.recording.duration
+    env: SPLUNK_PROFILER_RECORDING_DURATION
     description: Recording unit duration.
     default: 20s
     type: string
     category: profiler
-  - env: SPLUNK_PROFILER_KEEP_FILES
+  - property: splunk.profiler.keep-files
+    env: SPLUNK_PROFILER_KEEP_FILES
     description: Leave JFR files on disk if true.
     default: 'false'
     type: boolean
     category: profiler
-  - env: SPLUNK_PROFILER_LOGS_ENDPOINT
+  - property: splunk.profiler.logs-endpoint
+    env: SPLUNK_PROFILER_LOGS_ENDPOINT
     description: Where to send OTLP logs.
     default: otel.exporter.otlp.endpoint or http://localhost:4317
     type: string
     category: profiler
-  - env: SPLUNK_PROFILER_CALL_STACK_INTERVAL
+  - property: splunk.profiler.call.stack.interval
+    env: SPLUNK_PROFILER_CALL_STACK_INTERVAL
     description: How often to sample call stacks.
     default: 10000ms
     type: string
     category: profiler
-  - env: SPLUNK_PROFILER_MEMORY_ENABLED
+  - property: splunk.profiler.memory.enabled
+    env: SPLUNK_PROFILER_MEMORY_ENABLED
     description: Enables allocation profiler.
     default: 'false'
     type: boolean
     category: profiler
-  - env: SPLUNK_PROFILER_MEMORY_EVENT_RATE
+  - property: splunk.profiler.memory.event.rate
+    env: SPLUNK_PROFILER_MEMORY_EVENT_RATE
     description: Allocation event rate.
     default: 150/s
     type: string
     category: profiler
-  - env: SPLUNK_PROFILER_INCLUDE_INTERVAL_STACKS
+  - property: splunk.profiler.include.internal.stacks
+    env: SPLUNK_PROFILER_INCLUDE_INTERNAL_STACKS
     description: Set to `true` to include stack traces of agent internal threads and
       stack traces with only JDK internal frames.
     default: 'false'
     type: boolean
     category: profiler
-  - env: SPLUNK_PROFILER_TRACING_STACKS_ONLY
+  - property: splunk.profiler.tracing.stacks.only
+    env: SPLUNK_PROFILER_TRACING_STACKS_ONLY
     description: Set to `true` to include only stack traces that are linked to a span
       context.
     default: 'false'
     type: boolean
     category: profiler
-  - env: SPLUNK_PROFILER_OTLP_PROTOCOL
+  - property: splunk.profiler.otlp.protocol
+    env: SPLUNK_PROFILER_OTLP_PROTOCOL
     description: The transport protocol to use on profiling OTLP log requests. Options
       include grpc and http/protobuf.
     default: http/protobuf
     type: string
     category: profiler
-  - env: OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_SPAN_ATTRIBUTES
+  - property: otel.instrumentation.aws-sdk.experimental-span-attributes
+    env: OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_SPAN_ATTRIBUTES
     description: Enable the capture of experimental span attributes.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_USE_PROPAGATOR_FOR_MESSAGING
+  - property: otel.instrumentation.aws-sdk.experimental-use-propagator-for-messaging
+    env: OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_USE_PROPAGATOR_FOR_MESSAGING
     description: v2 only, inject into SNS/SQS attributes with configured propagator.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_USE_PROPAGATOR_FOR_MESSAGING
+  - property: otel.instrumentation.aws-sdk.experimental-use-propagator-for-messaging
+    env: OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_USE_PROPAGATOR_FOR_MESSAGING
     description: v2 only, record errors returned by each individual HTTP request as
       events for the SDK span.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_CAMEL_EXPERIMENTAL_SPAN_ATTRIBUTES
+  - property: otel.instrumentation.camel.experimental-span-attributes
+    env: OTEL_INSTRUMENTATION_CAMEL_EXPERIMENTAL_SPAN_ATTRIBUTES
     description: Enable the capture of experimental span attributes.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_COUCHBASE_EXPERIMENTAL_SPAN_ATTRIBUTES
+  - property: otel.instrumentation.apache-shenyu.experimental-span-attributes
+    env: OTEL_INSTRUMENTATION_APACHE_SHENYU_EXPERIMENTAL_SPAN_ATTRIBUTES
+    description: Enable the capture of experimental span attributes.
+    default: 'false'
+    type: boolean
+    category: instrumentation
+  - property: otel.instrumentation.couchbase.experimental-span-attributes
+    env: OTEL_INSTRUMENTATION_COUCHBASE_EXPERIMENTAL_SPAN_ATTRIBUTES
     description: Enables the capture of experimental span attributes (for version
       2.6 and higher of this instrumentation).
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_ELASTICSEARCH_CAPTURE_SEARCH_QUERY
+  - property: otel.instrumentation.elasticsearch.capture-search-query
+    env: OTEL_INSTRUMENTATION_ELASTICSEARCH_CAPTURE_SEARCH_QUERY
     description: 'Enable the capture of search query bodies. Attention: Elasticsearch
       queries may contain personal or sensitive information.'
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_ELASTICSEARCH_EXPERIMENTAL_SPAN_ATTRIBUTES
+  - property: otel.instrumentation.elasticsearch.experimental-span-attributes
+    env: OTEL_INSTRUMENTATION_ELASTICSEARCH_EXPERIMENTAL_SPAN_ATTRIBUTES
     description: Enable the capture of experimental span attributes.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_GRAPHQL_QUERY_SANITIZER_ENABLED
+  - property: otel.instrumentation.graphql.query-sanitizer.enabled
+    env: OTEL_INSTRUMENTATION_GRAPHQL_QUERY_SANITIZER_ENABLED
     description: Whether to remove sensitive information from query source that is
       added as span attribute.
     default: 'true'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_GRPC_EXPERIMENTAL_SPAN_ATTRIBUTES
+  - property: otel.instrumentation.graphql.data-fetcher.enabled
+    env: OTEL_INSTRUMENTATION_GRAPHQL_DATA_FETCHER_ENABLED
+    description: Whether to create spans for data fetchers (GraphQL 20 and later).
+    default: 'false'
+    type: boolean
+    category: instrumentation
+  - property: otel.instrumentation.graphql.trivial-data-fetcher.enabled
+    env: OTEL_INSTRUMENTATION_GRAPHQL_TRIVIAL_DATA_FETCHER_ENABLED
+    description: Whether to create spans for trivial data fetchers. A trivial data
+      fetcher is one that simply maps data from an object to a field (GraphQL 20 and
+      later).
+    default: 'false'
+    type: boolean
+    category: instrumentation
+  - property: otel.instrumentation.grpc.experimental-span-attributes
+    env: OTEL_INSTRUMENTATION_GRPC_EXPERIMENTAL_SPAN_ATTRIBUTES
     description: Enable the capture of experimental span attributes.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_GRPC_CAPTURE_METADATA_CLIENT_REQUEST
+  - property: otel.instrumentation.grpc.capture-metadata.client.request
+    env: OTEL_INSTRUMENTATION_GRPC_CAPTURE_METADATA_CLIENT_REQUEST
     description: A comma-separated list of request metadata keys. gRPC client instrumentation
       will capture metadata values corresponding to configured keys as span attributes.
     default: ''
     type: string
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_GRPC_CAPTURE_METADATA_SERVER_REQUEST
+  - property: otel.instrumentation.grpc.capture-metadata.server.request
+    env: OTEL_INSTRUMENTATION_GRPC_CAPTURE_METADATA_SERVER_REQUEST
     description: A comma-separated list of request metadata keys. gRPC server instrumentation
       will capture metadata values corresponding to configured keys as span attributes.
     default: ''
     type: string
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_GUAVA_EXPERIMENTAL_SPAN_ATTRIBUTES
+  - property: otel.instrumentation.guava.experimental-span-attributes
+    env: OTEL_INSTRUMENTATION_GUAVA_EXPERIMENTAL_SPAN_ATTRIBUTES
     description: Enable the capture of experimental span attributes.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_HIBERNATE_EXPERIMENTAL_SPAN_ATTRIBUTES
+  - property: otel.instrumentation.hibernate.experimental-span-attributes
+    env: OTEL_INSTRUMENTATION_HIBERNATE_EXPERIMENTAL_SPAN_ATTRIBUTES
     description: Enable the capture of experimental span attributes.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_HYSTRIX_EXPERIMENTAL_SPAN_ATTRIBUTES
+  - property: otel.instrumentation.hystrix.experimental-span-attributes
+    env: OTEL_INSTRUMENTATION_HYSTRIX_EXPERIMENTAL_SPAN_ATTRIBUTES
     description: Enable the capture of experimental span attributes.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_JAVA_UTIL_LOGGING_EXPERIMENTAL_LOG_ATTRIBUTES
+  - property: otel.instrumentation.java-util-logging.experimental-log-attributes
+    env: OTEL_INSTRUMENTATION_JAVA_UTIL_LOGGING_EXPERIMENTAL_LOG_ATTRIBUTES
     description: Enable the capture of experimental log attributes `thread.name` and
       `thread.id`.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_JAXRS_EXPERIMENTAL_SPAN_ATTRIBUTES
+  - property: otel.instrumentation.jaxrs.experimental-span-attributes
+    env: OTEL_INSTRUMENTATION_JAXRS_EXPERIMENTAL_SPAN_ATTRIBUTES
     description: Enable the capture of experimental span attributes.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_JBOSS_LOGMANAGER_EXPERIMENTAL_LOG_ATTRIBUTES
+  - property: otel.instrumentation.jboss-logmanager.experimental-log-attributes
+    env: OTEL_INSTRUMENTATION_JBOSS_LOGMANAGER_EXPERIMENTAL_LOG_ATTRIBUTES
     description: Enable the capture of experimental log attributes.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_JBOSS_LOGMANAGER_EXPERIMENTAL_CAPTURE_MDC_ATTRIBUTES
+  - property: otel.instrumentation.jboss-logmanager.experimental.capture-mdc-attributes
+    env: OTEL_INSTRUMENTATION_JBOSS_LOGMANAGER_EXPERIMENTAL_CAPTURE_MDC_ATTRIBUTES
     description: Comma separated list of MDC attributes to capture. Use the wildcard
       character `*` to capture all attributes.
     default: ''
     type: string
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_JDBC_STATEMENT_SANITIZER_ENABLED
-    description: EEnables the DB statement sanitization.
+  - property: otel.instrumentation.jdbc.statement-sanitizer.enabled
+    env: OTEL_INSTRUMENTATION_JDBC_STATEMENT_SANITIZER_ENABLED
+    description: Enables the DB statement sanitization.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_JSP_EXPERIMENTAL_SPAN_ATTRIBUTES
+  - property: otel.instrumentation.jsp.experimental-span-attributes
+    env: OTEL_INSTRUMENTATION_JSP_EXPERIMENTAL_SPAN_ATTRIBUTES
     description: Enable the capture of experimental span attributes.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_KAFKA_EXPERIMENTAL_SPAN_ATTRIBUTES
+  - property: otel.instrumentation.kafka.experimental-span-attributes
+    env: OTEL_INSTRUMENTATION_KAFKA_EXPERIMENTAL_SPAN_ATTRIBUTES
     description: Enable the capture of experimental span attributes.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_KAFKA_PRODUCER_PROPAGATION_ENABLED
+  - property: otel.instrumentation.kafka.producer-propagation.enabled
+    env: OTEL_INSTRUMENTATION_KAFKA_PRODUCER_PROPAGATION_ENABLED
     description: Enable context propagation for kafka message producer.
     default: 'true'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_KAFKA_METRIC_REPORTER_ENABLED
+  - property: otel.instrumentation.kafka.metric-reporter.enabled
+    env: OTEL_INSTRUMENTATION_KAFKA_METRIC_REPORTER_ENABLED
     description: Enable kafka consumer and producer metrics. Deprecated, disable instrumentation
       with name `kafka-clients-metrics` instead.
     default: 'true'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_KUBERNETES_CLIENT_EXPERIMENTAL_SPAN_ATTRIBUTES
+  - property: otel.instrumentation.kubernetes-client.experimental-span-attributes
+    env: OTEL_INSTRUMENTATION_KUBERNETES_CLIENT_EXPERIMENTAL_SPAN_ATTRIBUTES
     description: Enable the capture of experimental span attributes.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_LETTUCE_EXPERIMENTAL_SPAN_ATTRIBUTES
+  - property: otel.instrumentation.lettuce.experimental-span-attributes
+    env: OTEL_INSTRUMENTATION_LETTUCE_EXPERIMENTAL_SPAN_ATTRIBUTES
     description: Enable the capture of experimental span attributes.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_LOG4J_APPENDER_EXPERIMENTAL_LOG_ATTRIBUTES
+  - property: otel.instrumentation.log4j-appender.experimental-log-attributes
+    env: OTEL_INSTRUMENTATION_LOG4J_APPENDER_EXPERIMENTAL_LOG_ATTRIBUTES
     description: Enable the capture of experimental log attributes `thread.name` and
       `thread.id`.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_LOG4J_APPENDER_EXPERIMENTAL_CAPTURE_MAP_MESSAGE_ATTRIBUTES
+  - property: otel.instrumentation.log4j-appender.experimental.capture-map-message-attributes
+    env: OTEL_INSTRUMENTATION_LOG4J_APPENDER_EXPERIMENTAL_CAPTURE_MAP_MESSAGE_ATTRIBUTES
     description: Enable the capture of `MapMessage` attributes.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_LOG4J_APPENDER_EXPERIMENTAL_CAPTURE_MARKER_ATTRIBUTE
+  - property: otel.instrumentation.log4j-appender.experimental.capture-marker-attribute
+    env: OTEL_INSTRUMENTATION_LOG4J_APPENDER_EXPERIMENTAL_CAPTURE_MARKER_ATTRIBUTE
     description: Enable the capture of Log4j markers as attributes.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_LOG4J_APPENDER_EXPERIMENTAL_CAPTURE_MDC_ATTRIBUTES
+  - property: otel.instrumentation.log4j-appender.experimental.capture-mdc-attributes
+    env: OTEL_INSTRUMENTATION_LOG4J_APPENDER_EXPERIMENTAL_CAPTURE_MDC_ATTRIBUTES
     description: Comma separated list of context data attributes to capture. Use the
       wildcard character `*` to capture all attributes.
     default: ''
     type: string
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_COMMON_MDC_RESOURCE_ATTRIBUTES
+  - property: otel.instrumentation.log4j-context-data.add-baggage
+    env: OTEL_INSTRUMENTATION_LOG4J_CONTEXT_DATA_ADD_BAGGAGE
+    description: Enable exposing baggage attributes through MDC.
+    default: 'false'
+    type: boolean
+    category: instrumentation
+  - property: otel.instrumentation.common.mdc.resource-attributes
+    env: OTEL_INSTRUMENTATION_COMMON_MDC_RESOURCE_ATTRIBUTES
     description: Comma separated list of resource attributes to expose through MDC.
     default: ''
     type: string
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_LOGBACK_APPENDER_EXPERIMENTAL_LOG_ATTRIBUTES
+  - property: otel.instrumentation.logback-appender.experimental-log-attributes
+    env: OTEL_INSTRUMENTATION_LOGBACK_APPENDER_EXPERIMENTAL_LOG_ATTRIBUTES
     description: Enable the capture of experimental log attributes `thread.name` and
       `thread.id`.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_LOGBACK_APPENDER_EXPERIMENTAL_CAPTURE_CODE_ATTRIBUTES
+  - property: otel.instrumentation.logback-appender.experimental.capture-code-attributes
+    env: OTEL_INSTRUMENTATION_LOGBACK_APPENDER_EXPERIMENTAL_CAPTURE_CODE_ATTRIBUTES
     description: Enable the capture of [source code attributes](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/attributes.md#source-code-attributes).
       Note that capturing source code attributes at logging sites might add a performance
       overhead.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_LOGBACK_APPENDER_EXPERIMENTAL_CAPTURE_MARKER_ATTRIBUTE
+  - property: otel.instrumentation.logback-appender.experimental.capture-marker-attribute
+    env: OTEL_INSTRUMENTATION_LOGBACK_APPENDER_EXPERIMENTAL_CAPTURE_MARKER_ATTRIBUTE
     description: Enable the capture of Logback markers as attributes.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_LOGBACK_APPENDER_EXPERIMENTAL_CAPTURE_KEY_VALUE_PAIR_ATTRIBUTES
+  - property: otel.instrumentation.logback-appender.experimental.capture-key-value-pair-attributes
+    env: OTEL_INSTRUMENTATION_LOGBACK_APPENDER_EXPERIMENTAL_CAPTURE_KEY_VALUE_PAIR_ATTRIBUTES
     description: Enable the capture of Logback key value pairs as attributes.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_LOGBACK_APPENDER_EXPERIMENTAL_CAPTURE_LOGGER_CONTEXT_ATTRIBUTES
+  - property: otel.instrumentation.logback-appender.experimental.capture-logger-context-attributes
+    env: OTEL_INSTRUMENTATION_LOGBACK_APPENDER_EXPERIMENTAL_CAPTURE_LOGGER_CONTEXT_ATTRIBUTES
     description: Enable the capture of Logback logger context properties as attributes.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_LOGBACK_APPENDER_EXPERIMENTAL_CAPTURE_MDC_ATTRIBUTES
+  - property: otel.instrumentation.logback-appender.experimental.capture-mdc-attributes
+    env: OTEL_INSTRUMENTATION_LOGBACK_APPENDER_EXPERIMENTAL_CAPTURE_MDC_ATTRIBUTES
     description: Comma separated list of MDC attributes to capture. Use the wildcard
       character `*` to capture all attributes.
     default: ''
     type: string
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_LOGBACK_MDC_ADD_BAGGAGE
+  - property: otel.instrumentation.logback-mdc.add-baggage
+    env: OTEL_INSTRUMENTATION_LOGBACK_MDC_ADD_BAGGAGE
     description: Enable exposing baggage attributes through MDC.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_COMMON_MDC_RESOURCE_ATTRIBUTES
+  - property: otel.instrumentation.common.mdc.resource-attributes
+    env: OTEL_INSTRUMENTATION_COMMON_MDC_RESOURCE_ATTRIBUTES
     description: Comma separated list of resource attributes to expose through MDC.
     default: ''
     type: string
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_MICROMETER_BASE_TIME_UNIT
+  - property: otel.instrumentation.micrometer.base-time-unit
+    env: OTEL_INSTRUMENTATION_MICROMETER_BASE_TIME_UNIT
     description: Set the base time unit for the OpenTelemetry `MeterRegistry` implementation.
       <details><summary>Valid values</summary>`ns`, `nanoseconds`, `us`, `microseconds`,
       `ms`, `milliseconds`, `s`, `seconds`, `min`, `minutes`, `h`, `hours`, `d`, `days`</details>
     default: s
     type: string
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_MICROMETER_PROMETHEUS_MODE_ENABLED
+  - property: otel.instrumentation.micrometer.prometheus-mode.enabled
+    env: OTEL_INSTRUMENTATION_MICROMETER_PROMETHEUS_MODE_ENABLED
     description: Enable the "Prometheus mode" this will simulate the behavior of Micrometer's
       PrometheusMeterRegistry. The instruments will be renamed to match Micrometer
       instrument naming, and the base time unit will be set to seconds.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_MICROMETER_HISTOGRAM_GAUGES_ENABLED
+  - property: otel.instrumentation.micrometer.histogram-gauges.enabled
+    env: OTEL_INSTRUMENTATION_MICROMETER_HISTOGRAM_GAUGES_ENABLED
     description: Enables the generation of gauge-based Micrometer histograms for `DistributionSummary`
       and `Timer` instruments.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_MONGO_STATEMENT_SANITIZER_ENABLED
+  - property: otel.instrumentation.mongo.statement-sanitizer.enabled
+    env: OTEL_INSTRUMENTATION_MONGO_STATEMENT_SANITIZER_ENABLED
     description: Enables the DB statement sanitization.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_NETTY_CONNECTION_TELEMETRY_ENABLED
+  - property: otel.instrumentation.netty.connection-telemetry.enabled
+    env: OTEL_INSTRUMENTATION_NETTY_CONNECTION_TELEMETRY_ENABLED
     description: Enable the creation of Connect and DNS spans by default for Netty
       4.0 and higher instrumentation.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_NETTY_SSL_TELEMETRY_ENABLED
+  - property: otel.instrumentation.netty.ssl-telemetry.enabled
+    env: OTEL_INSTRUMENTATION_NETTY_SSL_TELEMETRY_ENABLED
     description: Enable SSL telemetry for Netty 4.0 and higher instrumentation.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_OPENTELEMETRY_ANNOTATIONS_EXCLUDE_METHODS
+  - property: otel.instrumentation.opentelemetry-annotations.exclude-methods
+    env: OTEL_INSTRUMENTATION_OPENTELEMETRY_ANNOTATIONS_EXCLUDE_METHODS
     description: All methods to be excluded from auto-instrumentation by annotation-based
       advices.
     default: ''
     type: string
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_OPENTELEMETRY_INSTRUMENTATION_ANNOTATIONS_EXCLUDE_METHODS
+  - property: otel.instrumentation.opentelemetry-instrumentation-annotations.exclude-methods
+    env: OTEL_INSTRUMENTATION_OPENTELEMETRY_INSTRUMENTATION_ANNOTATIONS_EXCLUDE_METHODS
     description: All methods to be excluded from auto-instrumentation by annotation-based
       advices.
     default: ''
     type: string
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_OSHI_EXPERIMENTAL_METRICS_ENABLED
+  - property: otel.instrumentation.oshi.experimental-metrics.enabled
+    env: OTEL_INSTRUMENTATION_OSHI_EXPERIMENTAL_METRICS_ENABLED
     description: Enable the OSHI metrics.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_PULSAR_EXPERIMENTAL_SPAN_ATTRIBUTES
+  - property: otel.instrumentation.pulsar.experimental-span-attributes
+    env: OTEL_INSTRUMENTATION_PULSAR_EXPERIMENTAL_SPAN_ATTRIBUTES
     description: Enable the capture of experimental span attributes.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_QUARTZ_EXPERIMENTAL_SPAN_ATTRIBUTES
+  - property: otel.instrumentation.quartz.experimental-span-attributes
+    env: OTEL_INSTRUMENTATION_QUARTZ_EXPERIMENTAL_SPAN_ATTRIBUTES
     description: Enable the capture of experimental span attributes.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_RABBITMQ_EXPERIMENTAL_SPAN_ATTRIBUTES
+  - property: otel.instrumentation.r2dbc.statement-sanitizer.enabled
+    env: OTEL_INSTRUMENTATION_R2DBC_STATEMENT_SANITIZER_ENABLED
+    description: Enables the DB statement sanitization.
+    default: 'false'
+    type: boolean
+    category: instrumentation
+  - property: otel.instrumentation.rabbitmq.experimental-span-attributes
+    env: OTEL_INSTRUMENTATION_RABBITMQ_EXPERIMENTAL_SPAN_ATTRIBUTES
     description: Enable the capture of experimental span attributes.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_REACTOR_EXPERIMENTAL_SPAN_ATTRIBUTES
+  - property: otel.instrumentation.reactor.experimental-span-attributes
+    env: OTEL_INSTRUMENTATION_REACTOR_EXPERIMENTAL_SPAN_ATTRIBUTES
     description: Enable the capture of experimental span attributes.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_REACTOR_NETTY_CONNECTION_TELEMETRY_ENABLED
+  - property: otel.instrumentation.reactor-netty.connection-telemetry.enabled
+    env: OTEL_INSTRUMENTATION_REACTOR_NETTY_CONNECTION_TELEMETRY_ENABLED
     description: Enable the creation of Connect and DNS spans by default.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_ROCKETMQ_CLIENT_EXPERIMENTAL_SPAN_ATTRIBUTES
+  - property: otel.instrumentation.rocketmq-client.experimental-span-attributes
+    env: OTEL_INSTRUMENTATION_ROCKETMQ_CLIENT_EXPERIMENTAL_SPAN_ATTRIBUTES
     description: Enable the capture of experimental span attributes.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_RUNTIME_TELEMETRY_EMIT_EXPERIMENTAL_TELEMETRY
+  - property: otel.instrumentation.runtime-telemetry.emit-experimental-telemetry
+    env: OTEL_INSTRUMENTATION_RUNTIME_TELEMETRY_EMIT_EXPERIMENTAL_TELEMETRY
     description: Enable the capture of experimental metrics.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_RUNTIME_TELEMETRY_JAVA17_ENABLE_ALL
+  - property: otel.instrumentation.runtime-telemetry-java17.enable-all
+    env: OTEL_INSTRUMENTATION_RUNTIME_TELEMETRY_JAVA17_ENABLE_ALL
     description: Enable the capture of all JFR based metrics.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_RUNTIME_TELEMETRY_JAVA17_ENABLED
+  - property: otel.instrumentation.runtime-telemetry-java17.enabled
+    env: OTEL_INSTRUMENTATION_RUNTIME_TELEMETRY_JAVA17_ENABLED
     description: Enable the capture of JFR based metrics.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_RUNTIME_TELEMETRY_PACKAGE_EMITTER_ENABLED
+  - property: otel.instrumentation.runtime-telemetry.package-emitter.enabled
+    env: OTEL_INSTRUMENTATION_RUNTIME_TELEMETRY_PACKAGE_EMITTER_ENABLED
     description: Enable creating events for JAR libraries used by the application.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_RUNTIME_TELEMETRY_PACKAGE_EMITTER_JARS_PER_SECOND
+  - property: otel.instrumentation.runtime-telemetry.package-emitter.jars-per-second
+    env: OTEL_INSTRUMENTATION_RUNTIME_TELEMETRY_PACKAGE_EMITTER_JARS_PER_SECOND
     description: The number of JAR files processed per second.
     default: '10'
     type: int
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_RXJAVA_EXPERIMENTAL_SPAN_ATTRIBUTES
+  - property: otel.instrumentation.rxjava.experimental-span-attributes
+    env: OTEL_INSTRUMENTATION_RXJAVA_EXPERIMENTAL_SPAN_ATTRIBUTES
     description: Enable the capture of experimental span attributes.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_SERVLET_EXPERIMENTAL_SPAN_ATTRIBUTES
+  - property: otel.instrumentation.servlet.experimental-span-attributes
+    env: OTEL_INSTRUMENTATION_SERVLET_EXPERIMENTAL_SPAN_ATTRIBUTES
     description: Enable the capture of experimental span attributes.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_SPRING_BATCH_ITEM_ENABLED
+  - property: otel.instrumentation.spring-batch.item.enabled
+    env: OTEL_INSTRUMENTATION_SPRING_BATCH_ITEM_ENABLED
     description: Enable creating span for each item.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_SPRING_BATCH_EXPERIMENTAL_CHUNK_NEW_TRACE
+  - property: otel.instrumentation.spring-batch.experimental.chunk.new-trace
+    env: OTEL_INSTRUMENTATION_SPRING_BATCH_EXPERIMENTAL_CHUNK_NEW_TRACE
     description: Enable staring a new trace for each chunk.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_SPRING_SCHEDULING_EXPERIMENTAL_SPAN_ATTRIBUTES
+  - property: otel.instrumentation.spring-scheduling.experimental-span-attributes
+    env: OTEL_INSTRUMENTATION_SPRING_SCHEDULING_EXPERIMENTAL_SPAN_ATTRIBUTES
     description: Enable the capture of experimental span attributes for Spring Batch
       version 3.0.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_SPRING_INTEGRATION_GLOBAL_CHANNEL_INTERCEPTOR_PATTERNS
+  - property: otel.instrumentation.spring-integration.global-channel-interceptor-patterns
+    env: OTEL_INSTRUMENTATION_SPRING_INTEGRATION_GLOBAL_CHANNEL_INTERCEPTOR_PATTERNS
     description: An array of Spring channel name patterns that will be intercepted.
       See [Spring Integration docs](https://docs.spring.io/spring-integration/reference/channel/configuration.html#global-channel-configuration-interceptors)
       for more details.
     default: '*'
     type: string
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_SPRING_INTEGRATION_PRODUCER_ENABLED
+  - property: otel.instrumentation.spring-integration.producer.enabled
+    env: OTEL_INSTRUMENTATION_SPRING_INTEGRATION_PRODUCER_ENABLED
     description: Create producer spans when messages are sent to an output channel.
       Enable when you're using a messaging library that doesn't have its own instrumentation
       for generating producer spans. Note that the detection of output channels only
@@ -1048,52 +1257,61 @@ settings:
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_SPRING_SCHEDULING_EXPERIMENTAL_SPAN_ATTRIBUTES
+  - property: otel.instrumentation.spring-scheduling.experimental-span-attributes
+    env: OTEL_INSTRUMENTATION_SPRING_SCHEDULING_EXPERIMENTAL_SPAN_ATTRIBUTES
     description: Enable the capture of experimental span attributes for Spring Scheduling
       version 3.1.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_SPRING_WEBFLUX_EXPERIMENTAL_SPAN_ATTRIBUTES
+  - property: otel.instrumentation.spring-webflux.experimental-span-attributes
+    env: OTEL_INSTRUMENTATION_SPRING_WEBFLUX_EXPERIMENTAL_SPAN_ATTRIBUTES
     description: Enable the capture of experimental span attributes for Spring WebFlux
       version 5.0.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_SPRING_WEBMVC_EXPERIMENTAL_SPAN_ATTRIBUTES
+  - property: otel.instrumentation.spring-webmvc.experimental-span-attributes
+    env: OTEL_INSTRUMENTATION_SPRING_WEBMVC_EXPERIMENTAL_SPAN_ATTRIBUTES
     description: Enable the capture of experimental span attributes for Spring Web
       MVC version 3.1.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_SPRING_CLOUD_GATEWAY_EXPERIMENTAL_SPAN_ATTRIBUTES
+  - property: otel.instrumentation.spring-cloud-gateway.experimental-span-attributes
+    env: OTEL_INSTRUMENTATION_SPRING_CLOUD_GATEWAY_EXPERIMENTAL_SPAN_ATTRIBUTES
     description: Enable the capture of experimental span attributes.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_SPRING_SECURITY_ENDUSER_ROLE_GRANTED_AUTHORITY_PREFIX
+  - property: otel.instrumentation.spring-security.enduser.role.granted-authority-prefix
+    env: OTEL_INSTRUMENTATION_SPRING_SECURITY_ENDUSER_ROLE_GRANTED_AUTHORITY_PREFIX
     description: Prefix of granted authorities identifying roles to capture in the
       `enduser.role` semantic attribute.
     default: ROLE_
     type: string
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_SPRING_SECURITY_ENDUSER_SCOPE_GRANTED_AUTHORITY_PREFIX
+  - property: otel.instrumentation.spring-security.enduser.scope.granted-authority-prefix
+    env: OTEL_INSTRUMENTATION_SPRING_SECURITY_ENDUSER_SCOPE_GRANTED_AUTHORITY_PREFIX
     description: Prefix of granted authorities identifying scopes to capture in the
       `enduser.scopes` semantic attribute.
     default: SCOPE_
     type: string
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_SPYMEMCACHED_EXPERIMENTAL_SPAN_ATTRIBUTES
+  - property: otel.instrumentation.spymemcached.experimental-span-attributes
+    env: OTEL_INSTRUMENTATION_SPYMEMCACHED_EXPERIMENTAL_SPAN_ATTRIBUTES
     description: Enable the capture of experimental span attributes.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_TWILIO_EXPERIMENTAL_SPAN_ATTRIBUTES
+  - property: otel.instrumentation.twilio.experimental-span-attributes
+    env: OTEL_INSTRUMENTATION_TWILIO_EXPERIMENTAL_SPAN_ATTRIBUTES
     description: Enable the capture of experimental span attributes.
     default: 'false'
     type: boolean
     category: instrumentation
-  - env: OTEL_INSTRUMENTATION_XXL_JOB_EXPERIMENTAL_SPAN_ATTRIBUTES
+  - property: otel.instrumentation.xxl-job.experimental-span-attributes
+    env: OTEL_INSTRUMENTATION_XXL_JOB_EXPERIMENTAL_SPAN_ATTRIBUTES
     description: Enable the capture of experimental span attributes.
     default: 'false'
     type: boolean
@@ -1909,6 +2127,13 @@ instrumentations:
     stability: experimental
     support: community
   - keys:
+      - apache-shenyu
+    instrumented_components:
+      - name: Apache ShenYu
+        supported_versions: 2.4 and higher
+    stability: experimental
+    support: community
+  - keys:
       - struts
     instrumented_components:
       - name: Apache Struts 2
@@ -1980,6 +2205,21 @@ instrumentations:
           - metric_name: http.server.request.body.size
             instrument: histogram
             description: Size of HTTP server response bodies (disabled by default).
+  - keys:
+      - armeria
+    instrumented_components:
+      - name: Armeria gRPC
+        supported_versions: 1.14 and higher
+    stability: experimental
+    support: community
+    signals:
+      - metrics:
+          - metric_name: rpc.client.duration
+            instrument: histogram
+            description: Measures the duration of outbound RPC.
+          - metric_name: rpc.server.duration
+            instrument: histogram
+            description: Measures the duration of inbound RPC.
   - keys:
       - async-http-client
     instrumented_components:
@@ -2324,6 +2564,13 @@ instrumentations:
     instrumented_components:
       - name: Hystrix
         supported_versions: 1.4 and higher
+    stability: experimental
+    support: community
+  - keys:
+      - influxdb
+    instrumented_components:
+      - name: InfluxDB Client
+        supported_versions: 2.4 and higher
     stability: experimental
     support: community
   - keys:
@@ -3242,14 +3489,6 @@ instrumentations:
         supported_versions: 20.0 and higher
     stability: experimental
     support: supported
-    signals:
-      - metrics:
-          - metric_name: executor.threads
-            instrument: gauge
-            description: The current number of threads in the pool.
-          - metric_name: executor.threads.active
-            instrument: gauge
-            description: The number of threads that are currently busy.
   - keys:
       - tomcat
       - tomcat-metrics-splunk
@@ -3258,30 +3497,6 @@ instrumentations:
         supported_versions: 7.0 and higher
     stability: experimental
     support: supported
-    signals:
-      - metrics:
-          - metric_name: executor.threads
-            instrument: gauge
-            description: The current number of threads in the pool.
-          - metric_name: executor.threads.active
-            instrument: gauge
-            description: The number of threads that are currently busy.
-          - metric_name: executor.threads.idle
-            instrument: gauge
-            description: The number of threads that are currently idle.
-          - metric_name: executor.threads.core
-            instrument: gauge
-            description: Core thread pool size - the number of threads that are always
-              kept in the pool.
-          - metric_name: executor.threads.max
-            instrument: gauge
-            description: The maximum number of threads in the pool.
-          - metric_name: executor.tasks.submitted
-            instrument: counter
-            description: The total number of tasks that were submitted to this executor.
-          - metric_name: executor.tasks.completed
-            instrument: counter
-            description: The total number of tasks completed by this executor.
   - keys:
       - tomee
     instrumented_components:
@@ -3297,17 +3512,6 @@ instrumentations:
         supported_versions: 12.1 and higher
     stability: experimental
     support: supported
-    signals:
-      - metrics:
-          - metric_name: executor.threads
-            instrument: gauge
-            description: The current number of threads in the pool.
-          - metric_name: executor.threads.idle
-            instrument: gauge
-            description: The number of threads that are currently idle.
-          - metric_name: executor.tasks.completed
-            instrument: counter
-            description: The total number of tasks completed by this executor.
   - keys:
       - websphere
     instrumented_components:
@@ -3333,7 +3537,7 @@ resource_detectors:
       - name: OpenTelemetry Java Instrumentation Resource Providers
         source_href: https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/resources/library
         package_href: https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-resources
-        version: 2.3.0-alpha
+        version: 2.4.0-alpha
         stability: experimental
   - key: io.opentelemetry.instrumentation.resources.HostIdResourceProvider
     description: Host id detector.
@@ -3345,7 +3549,7 @@ resource_detectors:
       - name: OpenTelemetry Java Instrumentation Resource Providers
         source_href: https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/resources/library
         package_href: https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-resources
-        version: 2.3.0-alpha
+        version: 2.4.0-alpha
         stability: experimental
   - key: io.opentelemetry.instrumentation.resources.HostResourceProvider
     description: Host detector.
@@ -3358,7 +3562,7 @@ resource_detectors:
       - name: OpenTelemetry Java Instrumentation Resource Providers
         source_href: https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/resources/library
         package_href: https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-resources
-        version: 2.3.0-alpha
+        version: 2.4.0-alpha
         stability: experimental
   - key: io.opentelemetry.instrumentation.resources.JarServiceNameDetector
     description: Jar service name detector.
@@ -3370,7 +3574,7 @@ resource_detectors:
       - name: OpenTelemetry Java Instrumentation Resource Providers
         source_href: https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/resources/library
         package_href: https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-resources
-        version: 2.3.0-alpha
+        version: 2.4.0-alpha
         stability: experimental
   - key: io.opentelemetry.instrumentation.resources.ManifestResourceProvider
     description: Manifest service name and version detector.
@@ -3383,7 +3587,7 @@ resource_detectors:
       - name: OpenTelemetry Java Instrumentation Resource Providers
         source_href: https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/resources/library
         package_href: https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-resources
-        version: 2.3.0-alpha
+        version: 2.4.0-alpha
         stability: experimental
   - key: io.opentelemetry.instrumentation.resources.OsResourceProvider
     description: Os detector.
@@ -3396,7 +3600,7 @@ resource_detectors:
       - name: OpenTelemetry Java Instrumentation Resource Providers
         source_href: https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/resources/library
         package_href: https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-resources
-        version: 2.3.0-alpha
+        version: 2.4.0-alpha
         stability: experimental
   - key: io.opentelemetry.instrumentation.resources.ProcessResourceProvider
     description: Process detector.
@@ -3411,7 +3615,7 @@ resource_detectors:
       - name: OpenTelemetry Java Instrumentation Resource Providers
         source_href: https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/resources/library
         package_href: https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-resources
-        version: 2.3.0-alpha
+        version: 2.4.0-alpha
         stability: experimental
   - key: io.opentelemetry.instrumentation.resources.ProcessRuntimeResourceProvider
     description: Process runtime detector.
@@ -3425,7 +3629,7 @@ resource_detectors:
       - name: OpenTelemetry Java Instrumentation Resource Providers
         source_href: https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/resources/library
         package_href: https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-resources
-        version: 2.3.0-alpha
+        version: 2.4.0-alpha
         stability: experimental
   - key: io.opentelemetry.instrumentation.spring.resources.SpringBootServiceNameDetector
     description: Spring boot service name detector.
@@ -3437,7 +3641,7 @@ resource_detectors:
       - name: OpenTelemetry Java Instrumentation Spring Boot Resource Providers
         source_href: https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/spring/spring-boot-resources/javaagent
         package_href: https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-spring-boot-resources
-        version: 2.3.0-alpha
+        version: 2.4.0-alpha
         stability: experimental
   - key: io.opentelemetry.instrumentation.spring.resources.SpringBootServiceVersionDetector
     description: Spring boot service version detector.
@@ -3449,7 +3653,7 @@ resource_detectors:
       - name: OpenTelemetry Java Instrumentation Spring Boot Resource Providers
         source_href: https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/spring/spring-boot-resources/javaagent
         package_href: https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-spring-boot-resources
-        version: 2.3.0-alpha
+        version: 2.4.0-alpha
         stability: experimental
   - key: io.opentelemetry.contrib.resourceproviders.AppServerServiceNameProvider
     description: Application server service name detector.

--- a/apm/splunk-otel-java/version
+++ b/apm/splunk-otel-java/version
@@ -1,1 +1,1 @@
-v2.3.0-alpha
+v2.4.0-alpha


### PR DESCRIPTION
Update splunk-otel-java version to `v2.4.0-alpha`.

See https://github.com/signalfx/splunk-otel-java/releases/tag/v2.4.0-alpha.