### PR TITLE
Update metadata.yaml

### DIFF
--- a/apm/splunk-otel-java/metadata.yaml
+++ b/apm/splunk-otel-java/metadata.yaml
@@ -33,14 +33,14 @@ settings:
     category: exporter
   - property: otel.metrics.exporter
     env: OTEL_METRICS_EXPORTER
-    description: List of exporters to be used for tracing, separated by commas. Default
+    description: List of exporters to be used for metrics, separated by commas. Default
       is otlp. none means no autoconfigured exporter.
     default: otlp
     type: string
     category: exporter
   - property: otel.logs.exporter
     env: OTEL_LOGS_EXPORTER
-    description: List of exporters to be used for tracing, separated by commas. Default
+    description: List of exporters to be used for logging, separated by commas. Default
       is otlp. none means no autoconfigured exporter.
     default: otlp
     type: string


### PR DESCRIPTION
For `OTEL_LOGS_EXPORTER`,  I corrected the text by changing the description from "List of exporters to be used for tracing, separated by commas. Default is otlp. none means no autoconfigured exporter." to "List of exporters to be used for logging, separated by commas. Default is otlp. none means no autoconfigured exporter." 

I did the same update for the description for OTEL_METRICS_EXPORTER to "List of exporters to be used for metrics..."