### PR TITLE
Fix links in the YAML files for .NET OTel and JS OTel

### DIFF
--- a/apm/splunk-otel-dotnet/metadata.yaml
+++ b/apm/splunk-otel-dotnet/metadata.yaml
@@ -310,7 +310,7 @@ instrumentations:
     support: community
     dependencies:
       - name: ASP.NET Core Instrumentation for OpenTelemetry .NET
-        source_href: https://github.com/open-telemetry/opentelemetry-dotnet-ontrib/tree/main/src/OpenTelemetry.Instrumentation.AspNetCore
+        source_href: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.AspNetCore
         package_href: https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNetCore
         version: 1.12.0
         stability: beta

--- a/apm/splunk-otel-js/metadata.yaml
+++ b/apm/splunk-otel-js/metadata.yaml
@@ -715,7 +715,7 @@ dependencies:
   - name: "@opentelemetry/propagator-aws-xray"
     version: "2.1.0"
     stability: "stable"
-    source_href: "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/propagators/propagator-aws-xray#readme"
+    source_href: "https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/packages/propagator-aws-xray/README.md"
   - name: "@opentelemetry/propagator-b3"
     version: "2.0.1"
     stability: "stable"


### PR DESCRIPTION
The YAML files are used to generate HTML tables in the docs, and we had broken links because the links in the YAML files were incorrect:
* https://github.com/open-telemetry/opentelemetry-dotnet-ontrib/tree/main/src/OpenTelemetry.Instrumentation.AspNetCore -> https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.AspNetCore
* https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/propagators/propagator-aws-xray -> https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/packages/propagator-aws-xray-lambda/README.md