### PR TITLE
Update dashboards_builtin_content.yaml - Fixing the YAML that had a duplicate entry.

### DIFF
--- a/ootb/dashboards_builtin_content.yaml
+++ b/ootb/dashboards_builtin_content.yaml
@@ -2134,7 +2134,6 @@ Dashboards:
   NodeJS runtime metrics:
     dashboard_group: APM NodeJS services
     view_support: N/A
-    importQualifiers: process.runtime.nodejs.memory.heap.total (*);
     importQualifiers: nodejs.memory.heap.total (*);
   OpenAI:
     dashboard_group: OpenAI


### PR DESCRIPTION
The PR https://github.com/splunk/o11y-gdi-metadata/blob/bits-o11y-doc-automation/ootb/dashboards_builtin_content.yaml to update this repo only had ` importQualifiers: nodejs.memory.heap.total (*);` for NodeJS runtime metrics:, but somehow the original was retained, so the YAML has two entries for `importQualifiers`, which is breaking our YAML-generated tables in the docs.